### PR TITLE
Login to Docker Hub only when using master/main branch

### DIFF
--- a/{{cookiecutter.stack_name}}/.github/workflows/docker.yml
+++ b/{{cookiecutter.stack_name}}/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
         {%- endraw %}
 
       - name: Push
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v2
         with:
           context: "."

--- a/{{cookiecutter.stack_name}}/.github/workflows/docker.yml
+++ b/{{cookiecutter.stack_name}}/.github/workflows/docker.yml
@@ -56,6 +56,7 @@ jobs:
         run: python -m pytest tests
 
       - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         uses: docker/login-action@v1
         with:
         {%- raw %}


### PR DESCRIPTION
It seems wrong to try to login to DockerHub in branches.
Unfortunately, nested workflow is not checked in an automatic way, because we would have to create a new repo and run workflows from there.

I think we might actually do it using https://github.com/nektos/act.
I might experiment with it because it seems to be a great tool.

I will at least try to make sure, that now after running cookiecutter we end up with a working GitHub project.
If I see any problems, I will create a PR for fixing them.